### PR TITLE
feat: add control numbers to success stories

### DIFF
--- a/app/admin/success-stories/page.tsx
+++ b/app/admin/success-stories/page.tsx
@@ -12,6 +12,7 @@ interface BarangayRequestPost {
   typeOfCalamity: string;
   batchNumber: number;
   donorIds: string[];
+  controlNumbers: string[];
 }
 
 export default function SuccessStoryForm() {
@@ -82,7 +83,7 @@ export default function SuccessStoryForm() {
             setFormData({
                 ...formData,
                 calamityName: selectedPost.typeOfCalamity,
-                controlNumber: selectedPost.id,
+                controlNumber: selectedPost.controlNumbers.join(", "),
                 transactionIds: selectedPost.donorIds.join(", "), // Join the array with commas
             });
         } else {

--- a/app/api/success-stories/route.ts
+++ b/app/api/success-stories/route.ts
@@ -42,6 +42,7 @@ export async function GET(req: Request) {
         donations: {
           select: {
             donorId: true,
+            controlNumber: true,
           },
         },
       },
@@ -52,7 +53,8 @@ export async function GET(req: Request) {
     const postsWithDonorIds = await Promise.all(
       barangayRequestPosts.map(async (post: any) => {
         const donorIds = Array.from(new Set(post.donations.map((donation: any) => donation.donorId))); // Get unique donorIds
-        return { ...post, donorIds };
+        const controlNumbers = Array.from(new Set(post.donations.map((donation: any) => donation.controlNumber))); // Get unique controlNumbers
+        return { ...post, donorIds, controlNumbers };
       })
     );
 


### PR DESCRIPTION
Add controlNumbers field to the BarangayRequestPost interface. 
Update the API to retrieve unique control numbers from donations 
and include them in the response. Modify the SuccessStoryForm 
to display control numbers correctly, enhancing the data 
structure and improving user experience.